### PR TITLE
Added perhaps a more simpler build process?

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -1,0 +1,12 @@
+{spawn, exec} = require 'child_process'
+
+task 'build', 'Watch source files and build JS & CSS', (options) ->
+
+  runCommand = (name, args) ->
+    proc =           spawn name, args
+    proc.stderr.on   'data', (buffer) -> console.log buffer.toString()
+    proc.stdout.on   'data', (buffer) -> console.log buffer.toString()
+    proc.on          'exit', (status) -> process.exit(1) if status != 0
+
+  runCommand 'compass', ['watch']
+  runCommand 'fuse',  ['-i', './js/fcbResponsive.js', '-o', './js/fcbResponsive.min.js', '-w']

--- a/README.md
+++ b/README.md
@@ -2,19 +2,11 @@
 
 Responsive framework for FarCry
 
-## CSS & JS Preprocessing
+## Buildtools
 
 ### CSS
 
-We use [COMPASS](http://compass-style.org/).
-
-To compile the scss to css, navigate to the root folder for the project:
-
-	compass watch [DIRECTORY]
-
-If you would like to compile the scss with with the debug info for easy css debuging in chrome
-
-	compass watch [DIRECTORY] --debug-info
+We're using [COMPASS][compass]. Make sure you have compass installed before getting started.
 
 If you recieve an error when compiling with compass about not finding the modular-scale package, please run this command in your command panel.
 
@@ -22,9 +14,23 @@ If you recieve an error when compiling with compass about not finding the modula
 
 ### JS
 
-We use [FUSE](https://github.com/smebberson/fuse)
+We're using [FUSE][fuse] to compile JavaScript. Make sure you have Fuse installed before getting started.
 
-To compile the javascript files, navigate to the /js folder and run:
+### Building fcbresponsive
 
+You can issue the following lines on your terminal (individual terminal sessions):
 
-	fuse -i fcbResponsive.js -o fcbResponsive.min.js
+	compass watch
+	fuse -i ./js/fcbResponsive.js -o ./js/fcbResponsive.min.js
+
+OR
+
+You can use cake with coffeescript and run one command:
+
+	cake build
+
+This will start both compass and fuse, and output any messages from either program to the console. Please note, you must have node.js installed, and also have the [coffee-script][csp] package installed and setup (global mode).
+
+[csp]: https://npmjs.org/package/coffee-script
+[compass]: http://compass-style.org/
+[fuse]: https://github.com/smebberson/fuse


### PR DESCRIPTION
Rather than having to use compass and fuse individually, you can simply
type 'cake build' and compass and fuse will be up and running.

Of course, you need to setup compass, fuse and coffee-script (on node.js and npm) first.
